### PR TITLE
Fix highlight color

### DIFF
--- a/plantacadastral.html
+++ b/plantacadastral.html
@@ -830,7 +830,7 @@
             L.geoJson(e, {
                 style: {
                     weight: 5,
-                    color: '##333',
+                    color: '#333',
                     dashArray: '',
                     fillOpacity: 0.5
                 }


### PR DESCRIPTION
## Summary
- correct map highlight style to use proper hex color

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684036ca12c8832f99c52df19d75d69a