### PR TITLE
Fix padding style in top bar

### DIFF
--- a/plantacadastral.html
+++ b/plantacadastral.html
@@ -58,7 +58,7 @@
             height: 38px;
             background-color: var(--base);
             color: #fff;
-            padding: 0 px;
+            padding: 0;
         }
 
         #logo {
@@ -90,7 +90,6 @@
             justify-content: flex-end;
             background-color: #fff;
             border: 0px solid #e9e9e9;
-            ;
             border-radius: 0px;
             padding: 6px;
             width: 315px;


### PR DESCRIPTION
## Summary
- fix padding declaration in `.top-bar`
- clean up stray semicolon in the search-box style

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840389f0f90832f99abc603f7866d91